### PR TITLE
[Vega] Add @RequireApiKey on webservices

### DIFF
--- a/vertigo-vega/src/main/java/io/vertigo/vega/VegaFeatures.java
+++ b/vertigo-vega/src/main/java/io/vertigo/vega/VegaFeatures.java
@@ -103,7 +103,7 @@ public final class VegaFeatures extends Features<VegaFeatures> {
 		return this;
 	}
 
-	@Feature("webservices.apiKey")
+	@Feature("webservices.auth.apiKey")
 	public VegaFeatures withApiKey(final Param... params) {
 		getModuleConfigBuilder()
 				.addPlugin(ApiKeyWebServiceHandlerPlugin.class, params);

--- a/vertigo-vega/src/main/java/io/vertigo/vega/VegaFeatures.java
+++ b/vertigo-vega/src/main/java/io/vertigo/vega/VegaFeatures.java
@@ -30,6 +30,7 @@ import io.vertigo.vega.impl.webservice.catalog.SwaggerWebServices;
 import io.vertigo.vega.impl.webservice.client.WebServiceClientProxyMethod;
 import io.vertigo.vega.plugins.webservice.handler.AccessTokenWebServiceHandlerPlugin;
 import io.vertigo.vega.plugins.webservice.handler.AnalyticsWebServiceHandlerPlugin;
+import io.vertigo.vega.plugins.webservice.handler.ApiKeyWebServiceHandlerPlugin;
 import io.vertigo.vega.plugins.webservice.handler.CorsAllowerWebServiceHandlerPlugin;
 import io.vertigo.vega.plugins.webservice.handler.ExceptionWebServiceHandlerPlugin;
 import io.vertigo.vega.plugins.webservice.handler.JsonConverterWebServiceHandlerPlugin;
@@ -99,6 +100,13 @@ public final class VegaFeatures extends Features<VegaFeatures> {
 				.addPlugin(SessionInvalidateWebServiceHandlerPlugin.class)
 				.addPlugin(SessionWebServiceHandlerPlugin.class)
 				.addPlugin(SecurityWebServiceHandlerPlugin.class);
+		return this;
+	}
+
+	@Feature("webservices.apiKey")
+	public VegaFeatures withApiKey(final Param... params) {
+		getModuleConfigBuilder()
+				.addPlugin(ApiKeyWebServiceHandlerPlugin.class, params);
 		return this;
 	}
 

--- a/vertigo-vega/src/main/java/io/vertigo/vega/plugins/webservice/handler/ApiKeyWebServiceHandlerPlugin.java
+++ b/vertigo-vega/src/main/java/io/vertigo/vega/plugins/webservice/handler/ApiKeyWebServiceHandlerPlugin.java
@@ -1,0 +1,76 @@
+/**
+ * vertigo - application development platform
+ *
+ * Copyright (C) 2013-2021, Vertigo.io, team@vertigo.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertigo.vega.plugins.webservice.handler;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import io.vertigo.account.authorization.VSecurityException;
+import io.vertigo.core.locale.MessageText;
+import io.vertigo.core.param.ParamValue;
+import io.vertigo.vega.impl.webservice.WebServiceHandlerPlugin;
+import io.vertigo.vega.webservice.definitions.WebServiceDefinition;
+import io.vertigo.vega.webservice.exception.SessionException;
+
+/**
+ * Security handler.
+ * Check Api Key, throw VSecurityException if not equals to configured Key.
+ *
+ * @author skerdudou
+ */
+public final class ApiKeyWebServiceHandlerPlugin implements WebServiceHandlerPlugin {
+
+	/** Stack index of the handler for sorting at startup **/
+	public static final int STACK_INDEX = 45;
+
+	private final String apiKey;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param securityManager Security Manager
+	 */
+	@Inject
+	public ApiKeyWebServiceHandlerPlugin(@ParamValue("apiKey") final String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public boolean accept(final WebServiceDefinition webServiceDefinition) {
+		return webServiceDefinition.isNeedApiKey();
+	}
+
+	@Override
+	public Object handle(final HttpServletRequest request, final HttpServletResponse response,
+			final WebServiceCallContext webServiceCallContext, final HandlerChain chain) throws SessionException {
+		final String providedApiKey = request.getHeader("apiKey");
+
+		if (!apiKey.equals(providedApiKey)) {
+			throw new VSecurityException(MessageText.of("Wrong apiKey"));
+		}
+		return chain.handle(request, response, webServiceCallContext);
+	}
+
+	@Override
+	public int getStackIndex() {
+		return STACK_INDEX;
+	}
+
+}

--- a/vertigo-vega/src/main/java/io/vertigo/vega/plugins/webservice/scanner/annotations/AnnotationsWebServiceScannerUtil.java
+++ b/vertigo-vega/src/main/java/io/vertigo/vega/plugins/webservice/scanner/annotations/AnnotationsWebServiceScannerUtil.java
@@ -55,6 +55,7 @@ import io.vertigo.vega.webservice.stereotype.PUT;
 import io.vertigo.vega.webservice.stereotype.PathParam;
 import io.vertigo.vega.webservice.stereotype.PathPrefix;
 import io.vertigo.vega.webservice.stereotype.QueryParam;
+import io.vertigo.vega.webservice.stereotype.RequireApiKey;
 import io.vertigo.vega.webservice.stereotype.ServerSideConsume;
 import io.vertigo.vega.webservice.stereotype.ServerSideRead;
 import io.vertigo.vega.webservice.stereotype.ServerSideSave;
@@ -96,6 +97,11 @@ public final class AnnotationsWebServiceScannerUtil {
 		if (pathPrefix != null) {
 			builder.withPathPrefix(pathPrefix.value());
 		}
+		final RequireApiKey requireApiKey = method.getDeclaringClass().getAnnotation(RequireApiKey.class);
+		if (requireApiKey != null) {
+			builder.withNeedApiKey(true);
+		}
+
 		for (final Annotation annotation : method.getAnnotations()) {
 			if (annotation instanceof GET) {
 				builder.with(Verb.Get, ((GET) annotation).value());
@@ -109,6 +115,8 @@ public final class AnnotationsWebServiceScannerUtil {
 				builder.with(Verb.Delete, ((DELETE) annotation).value());
 			} else if (annotation instanceof AnonymousAccessAllowed) {
 				builder.withNeedAuthentication(false);
+			} else if (annotation instanceof RequireApiKey) {
+				builder.withNeedApiKey(true);
 			} else if (annotation instanceof SessionLess) {
 				builder.withNeedSession(false);
 			} else if (annotation instanceof SessionInvalidate) {

--- a/vertigo-vega/src/main/java/io/vertigo/vega/webservice/definitions/WebServiceDefinition.java
+++ b/vertigo-vega/src/main/java/io/vertigo/vega/webservice/definitions/WebServiceDefinition.java
@@ -60,6 +60,7 @@ public final class WebServiceDefinition extends AbstractDefinition {
 	private final boolean needSession;
 	private final boolean sessionInvalidate;
 	private final boolean needAuthentification;
+	private final boolean needApiKey;
 
 	private final boolean accessTokenPublish;
 	private final boolean accessTokenMandatory;
@@ -87,6 +88,7 @@ public final class WebServiceDefinition extends AbstractDefinition {
 			final boolean needSession,
 			final boolean sessionInvalidate,
 			final boolean needAuthentification,
+			final boolean needApiKey,
 			final boolean accessTokenPublish,
 			final boolean accessTokenMandatory,
 			final boolean accessTokenConsume,
@@ -127,6 +129,7 @@ public final class WebServiceDefinition extends AbstractDefinition {
 		this.needSession = needSession;
 		this.sessionInvalidate = sessionInvalidate;
 		this.needAuthentification = needAuthentification;
+		this.needApiKey = needApiKey;
 
 		this.accessTokenPublish = accessTokenPublish;
 		this.accessTokenMandatory = accessTokenMandatory;
@@ -297,5 +300,12 @@ public final class WebServiceDefinition extends AbstractDefinition {
 	 */
 	public boolean isFileAttachment() {
 		return fileAttachment;
+	}
+
+	/**
+	 * @return the needApiKey
+	 */
+	public boolean isNeedApiKey() {
+		return needApiKey;
 	}
 }

--- a/vertigo-vega/src/main/java/io/vertigo/vega/webservice/definitions/WebServiceDefinitionBuilder.java
+++ b/vertigo-vega/src/main/java/io/vertigo/vega/webservice/definitions/WebServiceDefinitionBuilder.java
@@ -44,6 +44,7 @@ public final class WebServiceDefinitionBuilder implements Builder<WebServiceDefi
 	private boolean myNeedSession = true;
 	private boolean mySessionInvalidate;
 	private boolean myNeedAuthentication = true;
+	private boolean myNeedApiKey = false;
 	private final Set<String> myIncludedFields = new LinkedHashSet<>();
 	private final Set<String> myExcludedFields = new LinkedHashSet<>();
 	private boolean myAccessTokenPublish;
@@ -81,6 +82,7 @@ public final class WebServiceDefinitionBuilder implements Builder<WebServiceDefi
 				myNeedSession,
 				mySessionInvalidate,
 				myNeedAuthentication,
+				myNeedApiKey,
 				myAccessTokenPublish,
 				myAccessTokenMandatory,
 				myAccessTokenConsume,
@@ -170,6 +172,15 @@ public final class WebServiceDefinitionBuilder implements Builder<WebServiceDefi
 	 */
 	public WebServiceDefinitionBuilder withNeedAuthentication(final boolean needAuthentication) {
 		myNeedAuthentication = needAuthentication;
+		return this;
+	}
+
+	/**
+	 * @param needAuthentication needApiKey
+	 * @return this builder
+	 */
+	public WebServiceDefinitionBuilder withNeedApiKey(final boolean needApiKey) {
+		myNeedApiKey = needApiKey;
 		return this;
 	}
 

--- a/vertigo-vega/src/main/java/io/vertigo/vega/webservice/stereotype/RequireApiKey.java
+++ b/vertigo-vega/src/main/java/io/vertigo/vega/webservice/stereotype/RequireApiKey.java
@@ -1,0 +1,34 @@
+/**
+ * vertigo - application development platform
+ *
+ * Copyright (C) 2013-2021, Vertigo.io, team@vertigo.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertigo.vega.webservice.stereotype;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Require API KEY.
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RequireApiKey {
+	//
+}

--- a/vertigo-vega/src/test/java/io/vertigo/vega/webservice/AbstractWebServiceManagerTest.java
+++ b/vertigo-vega/src/test/java/io/vertigo/vega/webservice/AbstractWebServiceManagerTest.java
@@ -52,6 +52,7 @@ import io.vertigo.core.util.MapBuilder;
 
 abstract class AbstractWebServiceManagerTest {
 	private static final String HEADER_ACCESS_TOKEN = "x-access-token";
+	private static final String HEADER_API_KEY = "x-api-key";
 	private static final String UTF8_TEST_STRING = "? TM™ éè'`àöêõù Euro€ R®@©∆∏∑∞⅓۲²³œβ";
 
 	private final SessionFilter loggedSessionFilter = new SessionFilter();
@@ -319,6 +320,30 @@ abstract class AbstractWebServiceManagerTest {
 				.statusCode(HttpStatus.SC_FORBIDDEN)
 				.when()
 				.get("/test/oneTimeAccess/1");
+	}
+
+	@Test
+	public void testApiKeyOk() {
+		loggedAndExpect(given().header(HEADER_API_KEY, "MyTestApiKey"))
+				.statusCode(HttpStatus.SC_NO_CONTENT)
+				.when()
+				.get("/apiKeyAccess/");
+	}
+
+	@Test
+	public void testApiKeyNoHeader() {
+		loggedAndExpect()
+				.statusCode(HttpStatus.SC_FORBIDDEN)
+				.when()
+				.get("/apiKeyAccess/");
+	}
+
+	@Test
+	public void testApiKeyWrongKey() {
+		loggedAndExpect(given().header(HEADER_API_KEY, "WrongApiKey"))
+				.statusCode(HttpStatus.SC_FORBIDDEN)
+				.when()
+				.get("/apiKeyAccess/");
 	}
 
 	@Test

--- a/vertigo-vega/src/test/java/io/vertigo/vega/webservice/data/MyNodeConfig.java
+++ b/vertigo-vega/src/test/java/io/vertigo/vega/webservice/data/MyNodeConfig.java
@@ -48,6 +48,7 @@ import io.vertigo.vega.webservice.data.search.ContactSearchClient;
 import io.vertigo.vega.webservice.data.user.TestUserSession;
 import io.vertigo.vega.webservice.data.ws.AdvancedTestWebServices;
 import io.vertigo.vega.webservice.data.ws.AnonymousTestWebServices;
+import io.vertigo.vega.webservice.data.ws.ApiKeyWebServices;
 import io.vertigo.vega.webservice.data.ws.CommonWebServices;
 import io.vertigo.vega.webservice.data.ws.ContactsSecuredWebServices;
 import io.vertigo.vega.webservice.data.ws.ContactsWebServices;
@@ -90,7 +91,8 @@ public final class MyNodeConfig {
 				.withWebServicesSecurity()
 				.withWebServicesRateLimiting()
 				.withWebServicesSwagger()
-				.withWebServicesCatalog();
+				.withWebServicesCatalog()
+				.withApiKey(Param.of("apiKey", "MyTestApiKey"));
 
 		final ModuleConfigBuilder webserviceApp = ModuleConfig.builder("webservices-app")
 				.addComponent(ComponentCmdWebServices.class)
@@ -98,6 +100,7 @@ public final class MyNodeConfig {
 				.addComponent(ContactsWebServices.class)
 				.addComponent(ContactsSecuredWebServices.class)
 				.addComponent(LoginSecuredWebServices.class)
+				.addComponent(ApiKeyWebServices.class)
 				.addComponent(SimplerTestWebServices.class)
 				.addComponent(ValidationsTestWebServices.class)
 				.addComponent(AdvancedTestWebServices.class)

--- a/vertigo-vega/src/test/java/io/vertigo/vega/webservice/data/ws/ApiKeyWebServices.java
+++ b/vertigo-vega/src/test/java/io/vertigo/vega/webservice/data/ws/ApiKeyWebServices.java
@@ -1,0 +1,37 @@
+/**
+ * vertigo - application development platform
+ *
+ * Copyright (C) 2013-2021, Vertigo.io, team@vertigo.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.vertigo.vega.webservice.data.ws;
+
+import io.vertigo.vega.webservice.WebServices;
+import io.vertigo.vega.webservice.stereotype.AnonymousAccessAllowed;
+import io.vertigo.vega.webservice.stereotype.GET;
+import io.vertigo.vega.webservice.stereotype.PathPrefix;
+import io.vertigo.vega.webservice.stereotype.RequireApiKey;
+
+//basé sur http://www.restapitutorial.com/lessons/httpmethods.html
+
+@PathPrefix("/apiKeyAccess")
+public class ApiKeyWebServices implements WebServices {
+
+	@AnonymousAccessAllowed
+	@RequireApiKey
+	@GET("/")
+	public void test() {
+		//code 204
+	}
+}


### PR DESCRIPTION
Feature to protect some webservices with a fixed ApiKey via @RequireApiKey
Vega feature is added via :
```
  io.vertigo.vega.VegaFeatures:
      - webservices.apiKey:
          apiKey: ${API_KEY}
```
Usefull to protect some M2M endpoints easily.