### PR TITLE
Fix error when posting primitive value without 'modifiable="true"'

### DIFF
--- a/vertigo-ui/src/main/java/io/vertigo/ui/core/ViewContextUpdateSecurity.java
+++ b/vertigo-ui/src/main/java/io/vertigo/ui/core/ViewContextUpdateSecurity.java
@@ -130,11 +130,20 @@ public final class ViewContextUpdateSecurity implements Serializable {
 		if (allowedFields.contains(paramName)) {
 			return true;
 		}
+		if (isPrimitiveParam(paramName)) {
+			// primitive data must be in allowedFields
+			return false;
+		}
 		final String[] splitParamName = splitParamName(paramName);
 		final String object = splitParamName[SPLIT_OBJECT_INDEX];
 		final String row = splitParamName[SPLIT_ROW_INDEX];
 		final String fieldName = splitParamName[SPLIT_FIELD_INDEX];
 		return isAllowedField(object, row, fieldName);
+	}
+
+	private static boolean isPrimitiveParam(final String paramName) {
+		final int firstParam = paramName.indexOf('[');
+		return paramName.indexOf('[', firstParam + 1) == -1;
 	}
 
 	private static String[] splitObjectName(final String objectName) {


### PR DESCRIPTION
splitParamName with a primitive param (ex: `vContext[value]`) => IntexOutOfBoundException

with this fix, the param is denied with a comprehensible error message