### PR TITLE
[datafactory] DatabaseSearch: Corrige le cas des types incluant des paramètres

### DIFF
--- a/vertigo-datafactory/src/main/java/io/vertigo/datafactory/impl/collections/facet/model/FacetFactory.java
+++ b/vertigo-datafactory/src/main/java/io/vertigo/datafactory/impl/collections/facet/model/FacetFactory.java
@@ -40,7 +40,6 @@ import io.vertigo.datamodel.data.model.DataObject;
 import io.vertigo.datamodel.data.model.DtList;
 import io.vertigo.datamodel.data.util.VCollectors;
 import io.vertigo.datamodel.smarttype.SmartTypeManager;
-import io.vertigo.datamodel.smarttype.definitions.DtProperty;
 
 /**
  * Factory de FacetedQueryDefinition.
@@ -158,15 +157,15 @@ public final class FacetFactory {
 
 		//Cas des facettes par Term
 		final DataField dtField = facetDefinition.getDataField();
-		final String indexType = dtField.smartTypeDefinition().getProperties().getValue(DtProperty.INDEX_TYPE);
+		final var smartTypeDefinition = dtField.smartTypeDefinition();
 
 		//on garde un index pour incrémenter le facetFilter pour chaque Term
 		final Map<Object, FacetValue> facetFilterIndex = new HashMap<>();
 		for (final D data : dtList) {
 			final Object value = dtField.getDataAccessor().getValue(data);
-			final var valueAsString = smartTypeManager.valueToString(dtField.smartTypeDefinition(), value);
-			if (DtListPatternFilterUtil.isTokenizedIndexType(indexType)) {
-				for (final String token : DtListPatternFilterUtil.tokenizedIndexValue(indexType, valueAsString)) {
+			final var valueAsString = smartTypeManager.valueToString(smartTypeDefinition, value);
+			if (DtListPatternFilterUtil.isTokenizedIndexType(smartTypeDefinition)) {
+				for (final String token : DtListPatternFilterUtil.tokenizedIndexValue(smartTypeDefinition, valueAsString)) {
 					addTermToCluster(token, data, dtList, dtField, facetFilterIndex, clusterValues);
 				}
 			} else {

--- a/vertigo-datafactory/src/main/java/io/vertigo/datafactory/impl/collections/functions/filter/DtListPatternFilterUtil.java
+++ b/vertigo-datafactory/src/main/java/io/vertigo/datafactory/impl/collections/functions/filter/DtListPatternFilterUtil.java
@@ -30,12 +30,13 @@ import io.vertigo.core.lang.Assertion;
 import io.vertigo.core.lang.BasicType;
 import io.vertigo.core.lang.VSystemException;
 import io.vertigo.core.util.DateUtil;
+import io.vertigo.datafactory.collections.model.IndexType;
 import io.vertigo.datamodel.criteria.CriterionLimit;
 import io.vertigo.datamodel.criteria.Criterions;
 import io.vertigo.datamodel.data.definitions.DataDefinition;
 import io.vertigo.datamodel.data.definitions.DataField;
 import io.vertigo.datamodel.data.model.DataObject;
-import io.vertigo.datamodel.smarttype.definitions.DtProperty;
+import io.vertigo.datamodel.smarttype.definitions.SmartTypeDefinition;
 
 /**
  * Parser des filtres utilisant une syntaxe définie.
@@ -127,25 +128,31 @@ public final class DtListPatternFilterUtil {
 	}
 
 	/**
-	 * Retourne true si le type d'index est un type d'index tokenisé (ex: sep_comma, text_fr...).
+	 * Retourne true si le type d'index est un type d'index tokenisé (ex: sep_comma, sep_pipe:facetable...).
 	 * 
-	 * @param indexType Type d'index à tester
+	 * @param smartTypeDefinition SmartType à tester
 	 * @return true si le type d'index est un type d'index tokenisé, false sinon
 	 */
-	public static boolean isTokenizedIndexType(final String indexType) {
-		return TOKENIZED_INDEX_TYPES.containsKey(indexType);
+	public static boolean isTokenizedIndexType(final SmartTypeDefinition smartTypeDefinition) {
+		Assertion.check().isNotNull(smartTypeDefinition);
+		return IndexType.readIndexType(smartTypeDefinition)
+				.getIndexAnalyzer()
+				.map(TOKENIZED_INDEX_TYPES::containsKey)
+				.orElse(false);
 	}
 
 	/**
 	 * Retourne les tokens d'une valeur d'index tokenisé.
 	 * 
-	 * @param indexType Type d'index (ex: sep_comma, text_fr...)
+	 * @param smartTypeDefinition SmartType (ex: sep_comma, sep_pipe:facetable...)
 	 * @param value Valeur à tokeniser
 	 * @return Tableau de tokens
 	 */
-	public static String[] tokenizedIndexValue(final String indexType, final Object value) {
-		final Pattern pattern = TOKENIZED_INDEX_TYPES.get(indexType);
-		Assertion.check().isNotNull(pattern, "IndexType {0} is not tokenized", indexType);
+	public static String[] tokenizedIndexValue(final SmartTypeDefinition smartTypeDefinition, final Object value) {
+		Assertion.check().isNotNull(smartTypeDefinition);
+		final String indexAnalyzer = IndexType.readIndexType(smartTypeDefinition).getIndexAnalyzer().orElse(null);
+		final Pattern pattern = TOKENIZED_INDEX_TYPES.get(indexAnalyzer);
+		Assertion.check().isNotNull(pattern, "IndexType {0} is not tokenized", smartTypeDefinition.getName());
 		if (value == null) {
 			return new String[0];
 		}
@@ -153,9 +160,9 @@ public final class DtListPatternFilterUtil {
 	}
 
 	private static <D extends DataObject> Predicate<D> createDtListTermFilter(final String[] parsedFilter, final String fieldName, final BasicType dataType, final DataField dtField) {
-		final String indexType = dtField.smartTypeDefinition().getProperties().getValue(DtProperty.INDEX_TYPE);
-		if (isTokenizedIndexType(indexType)) {
-			return createDtListTermTokenizedFilter(parsedFilter, dtField, dataType, indexType);
+		final SmartTypeDefinition smartTypeDefinition = dtField.smartTypeDefinition();
+		if (isTokenizedIndexType(smartTypeDefinition)) {
+			return createDtListTermTokenizedFilter(parsedFilter, dtField, dataType, smartTypeDefinition);
 		}
 		return createDtListTermKeywordFilter(parsedFilter, fieldName, dataType);
 	}
@@ -171,7 +178,7 @@ public final class DtListPatternFilterUtil {
 		return predicate;
 	}
 
-	private static <D extends DataObject> Predicate<D> createDtListTermTokenizedFilter(final String[] parsedFilter, final DataField dtField, final BasicType dataType, final String indexType) {
+	private static <D extends DataObject> Predicate<D> createDtListTermTokenizedFilter(final String[] parsedFilter, final DataField dtField, final BasicType dataType, final SmartTypeDefinition smartTypeDefinition) {
 		Assertion.check().isTrue(dataType == BasicType.String, "Only String types can be used with tokenized indexType");
 
 		final String filterValue = parsedFilter[2];
@@ -182,7 +189,7 @@ public final class DtListPatternFilterUtil {
 				return false;
 			}
 
-			for (final String subValue : tokenizedIndexValue(indexType, value)) {
+			for (final String subValue : tokenizedIndexValue(smartTypeDefinition, value)) {
 				if (filterValue.equals(subValue)) {
 					return true;
 				}

--- a/vertigo-datafactory/src/test/java/io/vertigo/datafactory/collections/FacetManagerTest.java
+++ b/vertigo-datafactory/src/test/java/io/vertigo/datafactory/collections/FacetManagerTest.java
@@ -115,7 +115,7 @@ public class FacetManagerTest {
 		Assertions.assertEquals(smartCarDataBase.size(), result.getCount());
 
 		//On vérifie qu'il y a le bon nombre de facettes.
-		Assertions.assertEquals(4, result.getFacets().size());
+		Assertions.assertEquals(5, result.getFacets().size());
 
 		//On recherche la facette date
 		final Facet yearFacet = getFacetByName(result, "FctYearCar");
@@ -135,7 +135,7 @@ public class FacetManagerTest {
 		Assertions.assertEquals(smartCarDataBase.size(), result.getCount());
 
 		//On vérifie qu'il y a le bon nombre de facettes.
-		Assertions.assertEquals(4, result.getFacets().size());
+		Assertions.assertEquals(5, result.getFacets().size());
 
 		//On recherche la facette constructeur
 		final Facet manufacturerFacet = getFacetByName(result, "FctManufacturerCar");
@@ -333,6 +333,38 @@ public class FacetManagerTest {
 		final FacetedQuery query2 = addFacetQuery("FctDescriptionCarTokenized", "Attelage", resultFiltered);
 		final FacetedQueryResult<SmartCar, DtList<SmartCar>> resultFiltered2 = collectionsManager.facetList(resultFiltered.getSource(), query2, Optional.empty());
 		Assertions.assertEquals(smartCarDataBase.getCarsByDescription("gris métal", "Attelage").size(), (int) resultFiltered2.getCount());
+	}
+
+	/**
+	 * Test le facettage avec sélection multiple sur un champ sep_pipe:facetable (relations 1-N).
+	 */
+	@Test
+	public void testFilterFacetMultiListByTermSepPipeFacetable() {
+		final DtList<SmartCar> cars = smartCarDataBase.getAllCars();
+		final FacetedQuery facetedQuery = new FacetedQuery(carFacetQueryDefinition, SelectedFacetValues.empty().build());
+		final FacetedQueryResult<SmartCar, DtList<SmartCar>> result = collectionsManager.facetList(cars, facetedQuery, Optional.empty());
+
+		final Facet tagsFacet = getFacetByName(result, "FctTagsCar");
+		Assertions.assertEquals("tags", tagsFacet.getDefinition().getDataField().name());
+		Assertions.assertEquals(
+				smartCarDataBase.getCarsByTag("Attelage").size(),
+				getFacetValueCount(tagsFacet, "Attelage"));
+
+		final FacetedQuery query = addFacetQuery("FctTagsCar", "Attelage", result);
+		final FacetedQueryResult<SmartCar, DtList<SmartCar>> resultFiltered = collectionsManager.facetList(result.getSource(), query, Optional.empty());
+		Assertions.assertEquals(smartCarDataBase.getCarsByTag("Attelage").size(), (int) resultFiltered.getCount());
+
+		final FacetedQuery query2 = addFacetQuery("FctTagsCar", "7 places", resultFiltered);
+		final FacetedQueryResult<SmartCar, DtList<SmartCar>> resultFiltered2 = collectionsManager.facetList(resultFiltered.getSource(), query2, Optional.empty());
+		Assertions.assertEquals(smartCarDataBase.getCarsByTag("Attelage", "7 places").size(), (int) resultFiltered2.getCount());
+	}
+
+	private static long getFacetValueCount(final Facet facet, final String label) {
+		return facet.getFacetValues().entrySet().stream()
+				.filter(entry -> entry.getKey().label().getDisplay().equalsIgnoreCase(label))
+				.map(Entry::getValue)
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("Pas de FacetValue " + label + " dans la facette " + facet.getDefinition().getName()));
 	}
 
 	/**

--- a/vertigo-datafactory/src/test/java/io/vertigo/datafactory/collections/data/SmartCarSearchClient.java
+++ b/vertigo-datafactory/src/test/java/io/vertigo/datafactory/collections/data/SmartCarSearchClient.java
@@ -83,6 +83,12 @@ public class SmartCarSearchClient implements Component, DefinitionProvider {
 						.withLabel("Par mot clés")
 						.withMultiSelectable()
 						.withOrder(FacetOrder.count),
+				new FacetTermDefinitionSupplier("FctTagsCar")
+						.withDtDefinition("DtSmartCar")
+						.withFieldName("tags")
+						.withLabel("Par tags")
+						.withMultiSelectable()
+						.withOrder(FacetOrder.count),
 
 				//---
 				// FacetedQueryDefinition
@@ -94,6 +100,7 @@ public class SmartCarSearchClient implements Component, DefinitionProvider {
 						.withFacet("FctDescriptionCar")
 						.withFacet("FctManufacturerCar")
 						.withFacet("FctDescriptionCarTokenized")
+						.withFacet("FctTagsCar")
 						.withFacet("FctYearCar"));
 	}
 }

--- a/vertigo-datafactory/src/test/java/io/vertigo/datafactory/collections/data/TestCollectionsSmartTypes.java
+++ b/vertigo-datafactory/src/test/java/io/vertigo/datafactory/collections/data/TestCollectionsSmartTypes.java
@@ -34,6 +34,11 @@ public enum TestCollectionsSmartTypes {
 	Text,
 
 	@SmartTypeDefinition(String.class)
+	@SmartTypeProperty(property = "indexType", value = "sep_pipe:facetable")
+	@Formatter(clazz = FormatterDefault.class)
+	PipeText,
+
+	@SmartTypeDefinition(String.class)
 	@Formatter(clazz = FormatterDefault.class)
 	Keyword,
 

--- a/vertigo-datafactory/src/test/java/io/vertigo/datafactory/collections/data/domain/SmartCar.java
+++ b/vertigo-datafactory/src/test/java/io/vertigo/datafactory/collections/data/domain/SmartCar.java
@@ -35,6 +35,8 @@ public final class SmartCar implements KeyConcept {
 	private Integer year;
 	@Field(smartType = "STyText", cardinality = Cardinality.ONE, label = "Descriptif")
 	private String description;
+	@Field(smartType = "STyPipeText", cardinality = Cardinality.ONE, label = "Tags")
+	private String tags;
 
 	/** {@inheritDoc} */
 	@Override
@@ -64,6 +66,14 @@ public final class SmartCar implements KeyConcept {
 
 	public void setDescription(final String description) {
 		this.description = description;
+	}
+
+	public String getTags() {
+		return tags;
+	}
+
+	public void setTags(final String tags) {
+		this.tags = tags;
 	}
 
 	public Integer getYear() {

--- a/vertigo-datafactory/src/test/java/io/vertigo/datafactory/collections/data/domain/SmartCarDataBase.java
+++ b/vertigo-datafactory/src/test/java/io/vertigo/datafactory/collections/data/domain/SmartCarDataBase.java
@@ -17,11 +17,15 @@
  */
 package io.vertigo.datafactory.collections.data.domain;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import io.vertigo.datafactory.impl.collections.functions.filter.DtListPatternFilterUtil;
 import io.vertigo.datamodel.data.model.DtList;
+import io.vertigo.datamodel.data.util.DataModelUtil;
 import io.vertigo.datamodel.data.util.VCollectors;
+import io.vertigo.datamodel.smarttype.definitions.SmartTypeDefinition;
 
 /**
  * Base de données des voitures.
@@ -29,34 +33,52 @@ import io.vertigo.datamodel.data.util.VCollectors;
  * @author pchretien
  */
 public final class SmartCarDataBase {
+
+	private static final SmartTypeDefinition TAGS_SMART_TYPE = DataModelUtil.findDataDefinition(SmartCar.class).getField("tags").smartTypeDefinition();
+
 	private final List<SmartCar> cars;
 
 	public SmartCarDataBase() {
 		long id = 0;
 		cars = List.of(
-				createSmartCar(id++, "Peugeot", 2002, "Vds 307SW année 2002 137000 kms, gris métal, clim, CD, jantes alu, toit panoramique, 7 places (6 sièges), pneus neiges offerts, CT OK, TBE"),
+				createSmartCar(id++, "Peugeot", 2002,
+						"Vds 307SW année 2002 137000 kms, gris métal, clim, CD, jantes alu, toit panoramique, 7 places (6 sièges), pneus neiges offerts, CT OK, TBE",
+						"7 places|gris métal|clim|toit panoramique"),
 				createSmartCar(id++, "Audi", 2006,
-						"AUDI A3 S LINE TDI 1.9L 105ch 115 000 KM, Jantes 18, Intérieur semi cuir, noir, Feux automatique, Détecteur de pluie, Accoudoir central, Courroie de distribution neuve, Pneus avant récent"),
+						"AUDI A3 S LINE TDI 1.9L 105ch 115 000 KM, Jantes 18, Intérieur semi cuir, noir, Feux automatique, Détecteur de pluie, Accoudoir central, Courroie de distribution neuve, Pneus avant récent",
+						"Jantes 18|semi cuir|Feux automatique"),
 				createSmartCar(id++, "Volkswagen", 2010,
-						"NOUVEAU MOTEUR COMMON RAIL : plus silencieux et plus coupleux que les injecteurs-pompes...LE SEUL COUPE/CABRIOLET AVEC TOIT OUVRANT VERRE ELECTRIQUE... , Sièges chauffants, Ordinateur de bord"),
-				createSmartCar(id++, "Peugeot", 2001, "7 Places, Sièges cuir, Attelage, l'avenir est à nous"),
-				createSmartCar(id++, "Hyundai", 2004, "TRES BON ETAT, gris métal, Sièges chauffants, 4 roues motrices"),
+						"NOUVEAU MOTEUR COMMON RAIL : plus silencieux et plus coupleux que les injecteurs-pompes...LE SEUL COUPE/CABRIOLET AVEC TOIT OUVRANT VERRE ELECTRIQUE... , Sièges chauffants, Ordinateur de bord",
+						"Sièges chauffants|Ordinateur de bord|toit ouvrant"),
+				createSmartCar(id++, "Peugeot", 2001, "7 Places, Sièges cuir, Attelage, l'avenir est à nous",
+						"7 places|Sièges cuir|Attelage"),
+				createSmartCar(id++, "Hyundai", 2004, "TRES BON ETAT, gris métal, Sièges chauffants, 4 roues motrices",
+						"gris métal|Sièges chauffants|4 roues motrices"),
 				createSmartCar(id++, "Volkswagen", 2006,
-						"volskwagen noir/carnet d'entretien a jour ww/ toit ouvrant elect/ intr cuir/esp/hold parck/ordinateur de bord/ouverture de coffre commande a distance/etat impecable"),
+						"volskwagen noir/carnet d'entretien a jour ww/ toit ouvrant elect/ intr cuir/esp/hold parck/ordinateur de bord/ouverture de coffre commande a distance/etat impecable",
+						"cuir|toit ouvrant|ordinateur de bord"),
 				createSmartCar(id++, "Lancia", 2009,
-						"Catégorie partenaire : voiture occasion RARE SUR LE MARCHE DE L'OCCASION : LANCIA DELTA Di Lusso 1-4 t-jet ETAT IMPECCABLE FULL OPTIONS Planche de bord et sièges en cuir poltrona frau Magic Parking ( le véhicule fait son créneau sans toucher au volant, Double sortie d'échappement, Banquette arrière coulissante, Système blue and me ( USB)"),
+						"Catégorie partenaire : voiture occasion RARE SUR LE MARCHE DE L'OCCASION : LANCIA DELTA Di Lusso 1-4 t-jet ETAT IMPECCABLE FULL OPTIONS Planche de bord et sièges en cuir poltrona frau Magic Parking ( le véhicule fait son créneau sans toucher au volant, Double sortie d'échappement, Banquette arrière coulissante, Système blue and me ( USB)",
+						"cuir|Magic Parking|USB"),
 				createSmartCar(id++, "Peugeot", 1999,
-						"phare devil eyes, sieges, baquet omp, Intérieur cuir, pommeau de vitesse + pedale omp, volant racing, jante tole 106, rallye avec pneu , quasi neuf michelin, par choc avant+ arriere rallye, Kita admission , direct green, barre anti , raprochement omp, vidange faite final récemment par mes final soins tout , filtre changer, ligne avec final échappement récent , amortisseur combiné filetté"),
-				createSmartCar(id++, "Peugeot", 1998, "bon état, CD MP3 neuf, Attelage, garage s'abstenir"));
+						"phare devil eyes, sieges, baquet omp, Intérieur cuir, pommeau de vitesse + pedale omp, volant racing, jante tole 106, rallye avec pneu , quasi neuf michelin, par choc avant+ arriere rallye, Kita admission , direct green, barre anti , raprochement omp, vidange faite final récemment par mes final soins tout , filtre changer, ligne avec final échappement récent , amortisseur combiné filetté",
+						"Intérieur cuir|jantes|rallye"),
+				createSmartCar(id++, "Peugeot", 1998, "bon état, CD MP3 neuf, Attelage, garage s'abstenir",
+						"Attelage|CD MP3"));
 	}
 
-	private static SmartCar createSmartCar(final long id, final String manufacturer, final int year, final String description) {
+	private static SmartCar createSmartCar(
+			final long id,
+			final String manufacturer,
+			final int year,
+			final String description,
+			final String tags) {
 		final SmartCar car = new SmartCar();
 		car.setId(id);
 		car.setManufacturer(manufacturer);
 		car.setYear(year);
 		car.setDescription(description);
-		//-----
+		car.setTags(tags);
 		return car;
 	}
 
@@ -100,4 +122,14 @@ public final class SmartCarDataBase {
 				.toList();
 	}
 
+	/**
+	 * Retourne les voitures possédant au moins un des tags pipe-séparés (OR).
+	 */
+	public List<SmartCar> getCarsByTag(final String... tags) {
+		return cars
+				.stream()
+				.filter(car -> Arrays.stream(tags)
+						.anyMatch(tag -> Arrays.asList(DtListPatternFilterUtil.tokenizedIndexValue(TAGS_SMART_TYPE, car.getTags())).contains(tag)))
+				.toList();
+	}
 }


### PR DESCRIPTION
Permet d'utiliser des smart types avec ou sans paramètres, comme `sep_comma` et `sep_pipe:facetable`